### PR TITLE
Fix Beancount error when file has Custom entries

### DIFF
--- a/lua/cmp_beancount/init.lua
+++ b/lua/cmp_beancount/init.lua
@@ -30,9 +30,10 @@ local get_items = function(account_path)
         string.format(
             [[python3 <<EOB
 from beancount.loader import load_file
-f = load_file('%s')
-for item in f[0]:
-    print(item.account)
+entries, _, _ = load_file('%s')
+accounts = {t.account for t in entries if hasattr(t, 'account')}
+for account in accounts:
+    print(account)
 EOB]],
             account_path
         ),


### PR DESCRIPTION
Currently the plugin assumes there is a file that contains all the account opening transactions. This PR improves the method by enumerating all entries in the file with `.account` attributes and deduplicating them before outputing them to nvim-cmp.

The plugin can now loads the root Beancount file (similar to the behaviours of [nathangrigg/vim-beancount](https://github.com/nathangrigg/vim-beancount)) instead of the just the account opening file.
