### PR TITLE
Fix compatibility with blink.compat

### DIFF
--- a/lua/cmp_beancount/init.lua
+++ b/lua/cmp_beancount/init.lua
@@ -157,7 +157,7 @@ source.complete = function(self, request, callback)
                         range = {
                             start = {
                                 line = request.context.cursor.row - 1,
-                                character = request.offset - string.len(input),
+                                character = request.context.cursor.col - 1 - string.len(input),
                             },
                             ['end'] = {
                                 line = request.context.cursor.row - 1,


### PR DESCRIPTION
I've been having a lot of trouble figuring this one out, so please bear with me if I've gotten some things egregiously wrong.

cmp-beancount works just fine with nvim-cmp, but when used with [blink.compat](https://github.com/saghen/blink.compat), completions in "prefix mode" (_i.e.,_ those for keywords which include a colon) end up duplicating the first character.

In other words, `E<C-y>` correctly expands to **Equity:Opening-Balances**, but `E:T:F<C-y>` erroneously expands to **EExpenses:Taxes:Federal**. This appears to arise from a difference in how each plugin computes the value of `request.offset` (which appears to be `context.cursor.col - 1` in nvim-cmp and [simply `context.cursor.col` in blink.compat](https://github.com/saghen/blink.compat/blob/1454f14a8d855a578ceeba77c62538fa1459a67c/lua/blink/compat/source.lua#L56)).

I haven't been able to conclusively and confidently determine the cause of this discrepancy, but in my limited testing, this change does not break existing behavior with nvim-cmp, and _does_ fix the above bug in blink.compat.